### PR TITLE
Prevent NPE in `deallocate_pages`

### DIFF
--- a/exllamav2/generator/dynamic.py
+++ b/exllamav2/generator/dynamic.py
@@ -2545,8 +2545,9 @@ class ExLlamaV2DynamicJob:
             self.generator.all_pages[0].backup()
 
         for seq in self.sequences:
-            for page in seq.allocated_pages:
-                page.sub_ref()
-            seq.allocated_pages = []
+            if seq.allocated_pages is not None:
+                for page in seq.allocated_pages:
+                    page.sub_ref()
+                seq.allocated_pages = []
 
         self.generator.validate_cache()


### PR DESCRIPTION
If `deallocate_pages` is called on a job for which `allocate_pages` has not been called (see `iterate_start_jobs` for conditions under which this is true), `allocated_pages` is `None`, raising a NPE when attempting to iterate.

In particular, this prevents `clear_queue` from working. In practice, this problem readily occurs when starting a few jobs and then calling `clear_queue`.
